### PR TITLE
Lock sqlite3 gem version

### DIFF
--- a/solidus_jwt.gemspec
+++ b/solidus_jwt.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end


### PR DESCRIPTION
ActiveRecord 5.2.2 has sqlite3 dependency locked to `~> 1.3.6`, we need to reflect that in order to avoid conflicts due to sqlite3 1.4 version releasement.