### PR TITLE
Remove asset installation

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_jwt.js
+++ b/app/assets/javascripts/spree/backend/solidus_jwt.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'

--- a/app/assets/javascripts/spree/frontend/solidus_jwt.js
+++ b/app/assets/javascripts/spree/frontend/solidus_jwt.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/frontend/all.js'

--- a/app/assets/stylesheets/spree/backend/solidus_jwt.css
+++ b/app/assets/stylesheets/spree/backend/solidus_jwt.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/backend/all.css'
-*/

--- a/app/assets/stylesheets/spree/frontend/solidus_jwt.css
+++ b/app/assets/stylesheets/spree/frontend/solidus_jwt.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
-*/

--- a/lib/generators/solidus_jwt/install/install_generator.rb
+++ b/lib/generators/solidus_jwt/install/install_generator.rb
@@ -3,16 +3,6 @@ module SolidusJwt
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false
 
-      def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_jwt\n"
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_jwt\n"
-      end
-
-      def add_stylesheets
-        inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_jwt\n", before: /\*\//, verbose: true
-        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_jwt\n", before: /\*\//, verbose: true
-      end
-
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=solidus_jwt'
       end


### PR DESCRIPTION
Thanks for this gem :tada: 

I encountered that we unnecessarily append assets to the main apps assets manifests.
Since this gem does not ship any assets, appending empty assets to the main apps assets manifest files is not necessary.