### PR TITLE
Add foreign key to users

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,9 +1,8 @@
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('..', __dir__)
-ENGINE_PATH = File.expand_path('../lib/demo_engine/engine', __dir__)
-APP_PATH = File.expand_path('../spec/dummy/config/application', __dir__)
+ENGINE_PATH = File.expand_path('../lib/solidus_jwt/engine', __dir__)
 
-# Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'rails/all'
+require 'rails/engine/commands'

--- a/db/migrate/20191212083655_add_foreign_key_to_users_table.rb
+++ b/db/migrate/20191212083655_add_foreign_key_to_users_table.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToUsersTable < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :solidus_jwt_tokens, Spree.user_class.table_name, column: :user_id, on_delete: :cascade
+  end
+end


### PR DESCRIPTION
Having a foreign key between users table and the tokens table
is not only helping to maintain structural integrity in the database
it also mitigates security issues by making sure that the token
gets removed if the user gets deleted.