### PR TITLE
Fix Solidus dependencies

### DIFF
--- a/solidus_jwt.gemspec
+++ b/solidus_jwt.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jwt'
   s.add_dependency 'solidus_auth_devise'
-  s.add_dependency 'solidus_backend', ['>= 1.0', '< 3']
+  s.add_dependency 'solidus_api', ['>= 1.0', '< 3']
   s.add_dependency 'solidus_core', ['>= 1.0', '< 3']
   s.add_dependency 'solidus_support', '>= 0.1.3'
 


### PR DESCRIPTION
This gem depends on `solidus_core`, `solidus_api` and `solidus_auth_devise`.
Let's reflect that in the gemspec.