### PR TITLE
Fix table_name_prefix

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,0 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/app/models/solidus_jwt/application_record.rb
+++ b/app/models/solidus_jwt/application_record.rb
@@ -1,9 +1,0 @@
-module SolidusJwt
-  class ApplicationRecord < ::ApplicationRecord
-    self.abstract_class = true
-
-    def self.table_name_prefix
-      'solidus_jwt_'
-    end
-  end
-end

--- a/app/models/solidus_jwt/base_record.rb
+++ b/app/models/solidus_jwt/base_record.rb
@@ -1,0 +1,11 @@
+module SolidusJwt
+  base_class = defined?(::ApplicationRecord) ? ::ApplicationRecord : ActiveRecord::Base
+
+  class BaseRecord < base_class
+    self.abstract_class = true
+
+    def self.table_name_prefix
+      'solidus_jwt_'
+    end
+  end
+end

--- a/app/models/solidus_jwt/token.rb
+++ b/app/models/solidus_jwt/token.rb
@@ -1,5 +1,5 @@
 module SolidusJwt
-  class Token < ApplicationRecord
+  class Token < BaseRecord
     attr_readonly :token
     enum auth_type: %i[refresh_token access_token]
 


### PR DESCRIPTION
In some circumstances the `table_name_prefix` is not loaded
correctly from rails. If this happens the users `auth_tokens`
can not be loaded.

I actually do not why this does not work, we do not even have
an `ApplicationRecord` in our app. Anyhow the current setup is a bit
overcomplicated and does not even take into account that an app
might have an `ApplicationRecord`.

I removed the top level `ApplicationRecord` as this does not make any
sense in this gem. The namespaced `ApplicationRecord` has been renamed
to `BaseRecord`, since `ApplicationRecord` is reserved for Apps and should
not be used in Engines IMO.