### PR TITLE
Fix specs

### DIFF
--- a/solidus_jwt.gemspec
+++ b/solidus_jwt.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'
-  s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'gem-release'

--- a/spec/lib/devise_strategies/password_spec.rb
+++ b/spec/lib/devise_strategies/password_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spree/testing_support/factories/user_factory'
 
 RSpec.describe SolidusJwt::DeviseStrategies::Password do
   let(:request) { double(:request) }
@@ -13,7 +14,7 @@ RSpec.describe SolidusJwt::DeviseStrategies::Password do
   end
 
   let(:headers) { {} }
-  let(:user) { FactoryBot.create(:user, email: 'user@example.com', password: password) }
+  let(:user) { FactoryBot.create(:user, password: password) }
   let(:password) { 'secret' }
 
   before(:each) do

--- a/spec/lib/devise_strategies/refresh_token_spec.rb
+++ b/spec/lib/devise_strategies/refresh_token_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spree/testing_support/factories/user_factory'
 
 RSpec.describe SolidusJwt::DeviseStrategies::RefreshToken do
   let(:request) { double(:request) }
@@ -12,7 +13,7 @@ RSpec.describe SolidusJwt::DeviseStrategies::RefreshToken do
   end
 
   let(:headers) { {} }
-  let(:user) { FactoryBot.create(:user, email: 'user@example.com', password: password) }
+  let(:user) { FactoryBot.create(:user, password: password) }
   let(:password) { 'secret' }
   let(:token) { user.auth_tokens.create! }
 

--- a/spec/requests/spree/api/json_web_tokens_spec.rb
+++ b/spec/requests/spree/api/json_web_tokens_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spree/testing_support/factories/user_factory'
 
 RSpec.describe 'SolidusJwt Authentication', type: :request do
   let(:params) do

--- a/spec/requests/spree/api/oauths_spec.rb
+++ b/spec/requests/spree/api/oauths_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
+require 'spree/testing_support/factories/user_factory'
 
 RSpec.describe 'Token Retrieval', type: :request do
-  let(:user) { FactoryBot.create(:user, email: 'user@example.com', password: 'password') }
+  let(:user) { FactoryBot.create(:user, password: 'password') }
 
   describe '/api/token' do
     context 'when username and password are provided' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@ require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require 'byebug'
 require 'rspec/rails'
-require 'database_cleaner'
 require 'ffaker'
 
 # Requires supporting ruby files with custom matchers and macros, etc,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,5 +29,5 @@ require 'solidus_jwt/factories'
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 end


### PR DESCRIPTION
Fixes the specs by requiring the Solidus user factory.

Removes the `database_cleaner` gem as we do not use that and turn on transactional fixtures instead.