### PR TITLE
Change Devise strategy base class

### DIFF
--- a/app/controllers/spree/api/oauths_controller.rb
+++ b/app/controllers/spree/api/oauths_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       def token
         if user = try_authenticate_user
-          render_token_for(user)
+          render json: token_response_json(user)
         else
           render status: 401, json: { error: I18n.t(:invalid_credentials, scope: 'solidus_jwt') }
         end
@@ -13,10 +13,10 @@ module Spree
 
       private
 
-      def render_token_for(user)
+      def token_response_json(user)
         expires_in = SolidusJwt::Config.jwt_expiration
 
-        render json: {
+        {
           token_type: 'bearer',
           access_token: user.generate_jwt(expires_in: expires_in),
           expires_in: expires_in,

--- a/lib/solidus_jwt.rb
+++ b/lib/solidus_jwt.rb
@@ -4,6 +4,7 @@ require 'solidus_core'
 require 'solidus_auth_devise'
 require 'solidus_jwt/engine'
 
+require 'solidus_jwt/devise_strategies/base'
 require 'solidus_jwt/devise_strategies/password'
 require 'solidus_jwt/devise_strategies/refresh_token'
 

--- a/lib/solidus_jwt/devise_strategies/base.rb
+++ b/lib/solidus_jwt/devise_strategies/base.rb
@@ -1,0 +1,23 @@
+module SolidusJwt
+  module DeviseStrategies
+    class Base < Devise::Strategies::Authenticatable
+      def valid?
+        valid_grant_type? && valid_params?
+      end
+
+      private
+
+      def grant_type
+        params[:grant_type]
+      end
+
+      def valid_grant_type?
+        raise NotImplementedError
+      end
+
+      def valid_params?
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/solidus_jwt/devise_strategies/password.rb
+++ b/lib/solidus_jwt/devise_strategies/password.rb
@@ -1,10 +1,6 @@
 module SolidusJwt
   module DeviseStrategies
-    class Password < Devise::Strategies::Base
-      def valid?
-        valid_grant_type? && valid_params?
-      end
-
+    class Password < Base
       def authenticate!
         resource = mapping.to.find_for_database_authentication(auth_hash)
 
@@ -22,10 +18,6 @@ module SolidusJwt
 
       def auth_hash
         { email: username }
-      end
-
-      def grant_type
-        params[:grant_type]
       end
 
       def username

--- a/lib/solidus_jwt/devise_strategies/password.rb
+++ b/lib/solidus_jwt/devise_strategies/password.rb
@@ -2,8 +2,6 @@ module SolidusJwt
   module DeviseStrategies
     class Password < Base
       def authenticate!
-        resource = mapping.to.find_for_database_authentication(auth_hash)
-
         block = proc { resource.valid_password?(password) }
 
         if resource&.valid_for_authentication?(&block)
@@ -15,6 +13,10 @@ module SolidusJwt
       end
 
       private
+
+      def resource
+        @resource ||= mapping.to.find_for_database_authentication(auth_hash)
+      end
 
       def auth_hash
         { email: username }

--- a/lib/solidus_jwt/devise_strategies/refresh_token.rb
+++ b/lib/solidus_jwt/devise_strategies/refresh_token.rb
@@ -2,7 +2,6 @@ module SolidusJwt
   module DeviseStrategies
     class RefreshToken < Base
       def authenticate!
-        resource = SolidusJwt::Token.find_by(auth_hash)
         return fail!(:invalid) if resource.nil? || resource.user.nil?
 
         block = proc do
@@ -18,6 +17,10 @@ module SolidusJwt
       end
 
       private
+
+      def resource
+        @resource ||= SolidusJwt::Token.find_by(auth_hash)
+      end
 
       def auth_hash
         { auth_type: :refresh, token: refresh_token }

--- a/lib/solidus_jwt/devise_strategies/refresh_token.rb
+++ b/lib/solidus_jwt/devise_strategies/refresh_token.rb
@@ -1,10 +1,6 @@
 module SolidusJwt
   module DeviseStrategies
-    class RefreshToken < Devise::Strategies::Base
-      def valid?
-        valid_grant_type? && valid_params?
-      end
-
+    class RefreshToken < Base
       def authenticate!
         resource = SolidusJwt::Token.find_by(auth_hash)
         return fail!(:invalid) if resource.nil? || resource.user.nil?
@@ -25,10 +21,6 @@ module SolidusJwt
 
       def auth_hash
         { auth_type: :refresh, token: refresh_token }
-      end
-
-      def grant_type
-        params[:grant_type]
       end
 
       def refresh_token


### PR DESCRIPTION
`solidus_auth_devise` has the Rememberable module included.

This adds the possiblity for stores to add support for sending `remember_me` with params and
let the Devise strategies send the necessary cookie.