### PR TITLE
Handle other Warden strategy errors in API response

### DIFF
--- a/app/controllers/spree/api/oauths_controller.rb
+++ b/app/controllers/spree/api/oauths_controller.rb
@@ -4,8 +4,15 @@ module Spree
       skip_before_action :authenticate_user
 
       def token
-        if user = try_authenticate_user
-          render json: token_response_json(user)
+        result = catch(:warden) do
+          try_authenticate_user
+        end
+
+        case result
+        when Spree::User
+          render json: token_response_json(result)
+        when Hash
+          render status: 401, json: { error: I18n.t(result[:message], scope: 'devise.failure') }
         else
           render status: 401, json: { error: I18n.t(:invalid_credentials, scope: 'solidus_jwt') }
         end


### PR DESCRIPTION
If an app has other Devise modules enabled, [like `:lockable`](https://github.com/heartcombo/devise/blob/master/lib/devise/models/lockable.rb), we need to handle those in the OAuths controller as well.

Since the default Warden middleware responds with HTML, but we need to deliver JSON, we need to catch the `:warden` error and respond accordingly.