### PR TITLE
Update Spree::User.for_jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ By default, the token matches a user using the `Spree::User.for_jwt` method. Thi
 Finds a user by id using the subject claim of the token. If you want to customize how the
 subject claim is interpreted you can override this method
 
+**solidus_jwt 1.3 and greater**
+```ruby
+def self.for_jwt(payload)
+  # find_by(id: payload[:sub])
+  find_by(my_external_id: payload[:sub])
+end
+```
+
+**less than solidus_jwt 1.3**
 ```ruby
 def self.for_jwt(sub)
   # find_by(id: sub)

--- a/app/decorators/controllers/solidus_jwt/spree/api/base_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_jwt/spree/api/base_controller_decorator.rb
@@ -18,7 +18,7 @@ module SolidusJwt
           return super if json_web_token.blank?
 
           # rubocop:disable Naming/MemoizedInstanceVariableName
-          @current_api_user ||= ::Spree.user_class.for_jwt(json_web_token['sub'] || json_web_token['id'])
+          @current_api_user ||= ::Spree.user_class.for_jwt(json_web_token.with_indifferent_access)
           # rubocop:enable Naming/MemoizedInstanceVariableName
         end
 

--- a/app/decorators/models/solidus_jwt/spree/user_decorator.rb
+++ b/app/decorators/models/solidus_jwt/spree/user_decorator.rb
@@ -22,7 +22,20 @@ module SolidusJwt
         # @return [Spree.user_class, NilClass] If a match is found, returns the user,
         #   otherwise, returns nil
         #
-        def for_jwt(sub)
+        def for_jwt(payload)
+          sub = if payload.is_a?(Hash)
+                  payload = payload.with_indifferent_access
+                  payload[:sub] || payload[:id]
+                else
+                  SolidusJwt.deprecator.deprecation_warning(
+                    "Calling for_jwt on #{self.name} with the sub (String) as an argument", 
+                    "Signature will change from #{self.name}#for_jwt('some-id') to #{self.name}#for_jwt({ 'sub' => 'some-id' })", 
+                    caller
+                  )
+
+                  payload
+                end
+
           find_by(id: sub)
         end
       end

--- a/lib/solidus_jwt.rb
+++ b/lib/solidus_jwt.rb
@@ -13,6 +13,7 @@ require 'solidus_jwt/devise_strategies/refresh_token'
 
 require 'solidus_jwt/version'
 require 'solidus_jwt/config'
+require 'solidus_jwt/deprecator'
 require 'solidus_jwt/concerns/decodeable'
 require 'solidus_jwt/concerns/encodeable'
 require 'solidus_jwt/distributor/devise'
@@ -20,4 +21,6 @@ require 'solidus_jwt/distributor/devise'
 module SolidusJwt
   extend Decodeable
   extend Encodeable
+
+  extend Deprecator
 end

--- a/lib/solidus_jwt/deprecator.rb
+++ b/lib/solidus_jwt/deprecator.rb
@@ -1,0 +1,10 @@
+module SolidusJwt
+  module Deprecator
+    def deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new(
+        Gem::Version.new(VERSION).bump, 
+        'SolidusJwt'
+      )
+    end
+  end
+end

--- a/lib/solidus_jwt/version.rb
+++ b/lib/solidus_jwt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusJwt
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/decorators/models/solidus_jwt/spree/user_decorator_spec.rb
+++ b/spec/decorators/models/solidus_jwt/spree/user_decorator_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe Spree::User, type: :model do
+  describe '.for_jwt' do
+    subject { described_class.for_jwt(payload) }
+
+    before do
+      allow(described_class).to receive(:find_by).with(hash_including(id: String))
+    end
+
+    context 'when payload is a string' do
+      let(:payload) { 'user-id' }
+
+      it 'must call deprecator' do
+        allow(SolidusJwt.deprecator).to receive(:deprecation_warning)
+
+        described_class.for_jwt(payload)
+
+        expect(SolidusJwt.deprecator).to have_received(:deprecation_warning)
+      end
+
+      it 'must call .find_by with { id: String } signature' do
+        described_class.for_jwt(payload)
+
+        expect(described_class).to have_received(:find_by).with(hash_including(id: payload))
+      end
+    end
+
+    context 'when payload is a Hash' do
+      let(:payload) do
+        {
+          sub: 'user-id',
+          email: 'abc@example.com',
+          iss: 'solidus'
+        }
+      end
+
+      it 'must NOT call deprecator' do
+        allow(SolidusJwt.deprecator).to receive(:deprecation_warning)
+
+        described_class.for_jwt(payload)
+
+        expect(SolidusJwt.deprecator).to_not have_received(:deprecation_warning)
+      end
+
+      it 'must call .find_by with { id: String } signature' do
+        described_class.for_jwt(payload)
+
+        expect(described_class).to have_received(:find_by).with(hash_including(id: payload[:sub]))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #29

Update the Spree::User.for_jwt method so that the entire payload of the
json web token is passed in rather than just the subject.

This allows developers overriding the method to have greater access
to what is in the token. For example an idp id or name.