### PR TITLE
relaxing solidus_core lower than v3 dependency

### DIFF
--- a/solidus_jwt.gemspec
+++ b/solidus_jwt.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jwt'
   s.add_dependency 'solidus_auth_devise'
-  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
+  s.add_dependency 'solidus_core'
   s.add_dependency 'solidus_support', '~> 0.5.0'
 
   s.add_development_dependency 'byebug'


### PR DESCRIPTION
Can we relaxing this dependency, because it's unable to use on the projects with core greater than v3... :(