### PR TITLE
Bump Solidus Version in Gemspec to Allow Above 3.0

### DIFF
--- a/solidus_jwt.gemspec
+++ b/solidus_jwt.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jwt'
   s.add_dependency 'solidus_auth_devise'
-  s.add_dependency 'solidus_core', '>= 2.0.0'
+  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support'
 
   s.add_development_dependency 'byebug'


### PR DESCRIPTION
Prevents the error:
    solidus_jwt was resolved to 1.2.0, which depends on
      solidus_core (< 3, >= 2.0.0)
Tested with latest Solidus and bundler versions.