### PR TITLE
Allow Non-Expiring Refresh Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 SolidusJwt
 ==========
 
-[![CircleCI](https://circleci.com/gh/skukx/solidus_jwt.svg?style=svg)](https://circleci.com/gh/skukx/solidus_jwt)
 [![Gem Version](https://badge.fury.io/rb/solidus_jwt.svg)](https://badge.fury.io/rb/solidus_jwt)
 
 This gem gives [Solidus](https://github.com/solidusio/solidus) stores the ability to authenticate API requests with
@@ -58,7 +57,7 @@ Defaults to `3600` (1 hour). The amount of time in seconds that the token should
 Defaults to `{ only: %i[email first_name id last_name] }`. These options are passed into `Spree::User#as_json` when serializing the token's payload.  Keep in mind that the more information included, the larger the token will be. It may be in your best interest to keep it short and simple.
 
 #### `refresh_expiration`:
-Defaults to `2592000` (30 days). The amount of time in seconds that the token should last for.
+Defaults to `2592000` (30 days). The amount of time in seconds that the token should last for. Optionally, this may be set to nil so that refresh tokens never expire
 
 Usage
 -------------

--- a/app/models/solidus_jwt/token.rb
+++ b/app/models/solidus_jwt/token.rb
@@ -20,6 +20,17 @@ module SolidusJwt
       end
     }
 
+    scope :honorable, -> {
+      if SolidusJwt::Config.refresh_expiration
+        where(
+          'solidus_jwt_tokens.created_at >= ?',
+          SolidusJwt::Config.refresh_expiration.seconds.ago
+        ).where(active: true)
+      else
+        where(active: true)
+      end
+    }
+
     enum auth_type: { refresh: 0, access: 1 }
 
     validates :token, presence: true

--- a/app/models/solidus_jwt/token.rb
+++ b/app/models/solidus_jwt/token.rb
@@ -10,10 +10,14 @@ module SolidusJwt
     # rubocop:enable Rails/ReflectionClassName
 
     scope :non_expired, -> {
-      where(
-        'solidus_jwt_tokens.created_at >= ?',
-        SolidusJwt::Config.refresh_expiration.seconds.ago
-      )
+      if SolidusJwt::Config.refresh_expiration
+        where(
+          'solidus_jwt_tokens.created_at >= ?',
+          SolidusJwt::Config.refresh_expiration.seconds.ago
+        )
+      else
+        all
+      end
     }
 
     enum auth_type: { refresh: 0, access: 1 }
@@ -57,7 +61,11 @@ module SolidusJwt
     #   expiration amount then will be true. Otherwise false.
     #
     def expired?
-      created_at < SolidusJwt::Config.refresh_expiration.seconds.ago
+      if SolidusJwt::Config.refresh_expiration
+        created_at < SolidusJwt::Config.refresh_expiration.seconds.ago
+      else
+        false
+      end
     end
   end
 end

--- a/db/migrate/20230312204231_add_client_id_to_refresh_token.rb
+++ b/db/migrate/20230312204231_add_client_id_to_refresh_token.rb
@@ -1,0 +1,5 @@
+class AddClientIdToRefreshToken < ActiveRecord::Migration[7.0]
+  def change
+    add_column :solidus_jwt_tokens, :client_id, :string
+  end
+end

--- a/db/migrate/20230312204231_add_client_id_to_refresh_token.rb
+++ b/db/migrate/20230312204231_add_client_id_to_refresh_token.rb
@@ -1,4 +1,4 @@
-class AddClientIdToRefreshToken < ActiveRecord::Migration[7.0]
+class AddClientIdToRefreshToken < ActiveRecord::Migration[5.2]
   def change
     add_column :solidus_jwt_tokens, :client_id, :string
   end

--- a/db/migrate/20230315045456_add_index_to_client_id_refresh_token.rb
+++ b/db/migrate/20230315045456_add_index_to_client_id_refresh_token.rb
@@ -1,0 +1,5 @@
+class AddIndexToClientIdRefreshToken < ActiveRecord::Migration[5.2]
+  def change
+    add_index :solidus_jwt_tokens, :client_id
+  end
+end


### PR DESCRIPTION
In the case of mobile apps, it's desirable to never expire refresh tokens. These modifications add support for this. Happy to add tests or whatever necessary to contribute this in. 